### PR TITLE
Notification

### DIFF
--- a/taskpilot-users/src/main/java/com/taskpilot/users/repository/SkillRepository.java
+++ b/taskpilot-users/src/main/java/com/taskpilot/users/repository/SkillRepository.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 @Repository
 public interface SkillRepository extends JpaRepository<SkillEntity, Long> {
+
     Optional<SkillEntity> findByName(String name);
 
     Optional<SkillEntity> findByIdAndIsActiveTrue(Long id);

--- a/taskpilot-users/src/main/java/com/taskpilot/users/repository/SkillRepository.java
+++ b/taskpilot-users/src/main/java/com/taskpilot/users/repository/SkillRepository.java
@@ -6,15 +6,18 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface SkillRepository extends JpaRepository<SkillEntity, Long> {
     Optional<SkillEntity> findByName(String name);
 
+    Optional<SkillEntity> findByIdAndIsActiveTrue(Long id);
+
     boolean existsByNameIgnoreCase(String name);
 
     Page<SkillEntity> findByNameContainingIgnoreCase(String name, Pageable pageable);
 
-    Page<SkillEntity> findAll(Pageable pageable);
+    List<SkillEntity> findByIsActiveTrueOrderByNameAsc();
 }

--- a/taskpilot-users/src/main/java/com/taskpilot/users/skills/controller/SkillController.java
+++ b/taskpilot-users/src/main/java/com/taskpilot/users/skills/controller/SkillController.java
@@ -2,6 +2,7 @@ package com.taskpilot.users.skills.controller;
 
 import com.taskpilot.infrastructure.dto.ApiResponse;
 import com.taskpilot.users.skills.dto.AddSkillRequest;
+import com.taskpilot.users.skills.dto.SkillDirectoryResponse;
 import com.taskpilot.users.skills.dto.UpdateSkillRequest;
 import com.taskpilot.users.skills.dto.UserSkillResponse;
 import com.taskpilot.users.skills.service.SkillService;
@@ -26,6 +27,13 @@ public class SkillController {
     @GetMapping
     public ApiResponse<List<UserSkillResponse>> getMySkills() {
         return ApiResponse.success(HttpStatus.OK.value(), "Skills retrieved successfully", skillService.getMySkills());
+    }
+
+    @Operation(summary = "View Skill Directory", description = "Get active system skills that user can add.")
+    @GetMapping("/directory")
+    public ApiResponse<List<SkillDirectoryResponse>> getSkillDirectory() {
+        return ApiResponse.success(HttpStatus.OK.value(), "Skill directory retrieved successfully",
+                skillService.getSkillDirectory());
     }
 
     @Operation(summary = "View Detail", description = "Get detail of a specific skill for the current user.")

--- a/taskpilot-users/src/main/java/com/taskpilot/users/skills/dto/AddSkillRequest.java
+++ b/taskpilot-users/src/main/java/com/taskpilot/users/skills/dto/AddSkillRequest.java
@@ -7,10 +7,10 @@ import jakarta.validation.constraints.NotNull;
 public record AddSkillRequest(
         @NotNull(message = "Skill id cannot be null")
         Long skillId,
-
-        @NotNull(message = "Level cannot be null") 
-        @Min(value = 1, message = "Level must be between 1 and 5") 
-        @Max(value = 5, message = "Level must be between 1 and 5") 
+        @NotNull(message = "Level cannot be null")
+        @Min(value = 1, message = "Level must be between 1 and 5")
+        @Max(value = 5, message = "Level must be between 1 and 5")
         Integer level
-) {
+        ) {
+
 }

--- a/taskpilot-users/src/main/java/com/taskpilot/users/skills/dto/AddSkillRequest.java
+++ b/taskpilot-users/src/main/java/com/taskpilot/users/skills/dto/AddSkillRequest.java
@@ -2,12 +2,11 @@ package com.taskpilot.users.skills.dto;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record AddSkillRequest(
-        @NotBlank(message = "Skill name cannot be blank") 
-        String name,
+        @NotNull(message = "Skill id cannot be null")
+        Long skillId,
 
         @NotNull(message = "Level cannot be null") 
         @Min(value = 1, message = "Level must be between 1 and 5") 

--- a/taskpilot-users/src/main/java/com/taskpilot/users/skills/dto/SkillDirectoryResponse.java
+++ b/taskpilot-users/src/main/java/com/taskpilot/users/skills/dto/SkillDirectoryResponse.java
@@ -6,7 +6,8 @@ public record SkillDirectoryResponse(
         Long id,
         String name,
         String description
-) {
+        ) {
+
     public static SkillDirectoryResponse fromEntity(SkillEntity skill) {
         return new SkillDirectoryResponse(skill.getId(), skill.getName(), skill.getDescription());
     }

--- a/taskpilot-users/src/main/java/com/taskpilot/users/skills/dto/SkillDirectoryResponse.java
+++ b/taskpilot-users/src/main/java/com/taskpilot/users/skills/dto/SkillDirectoryResponse.java
@@ -1,0 +1,13 @@
+package com.taskpilot.users.skills.dto;
+
+import com.taskpilot.users.entity.SkillEntity;
+
+public record SkillDirectoryResponse(
+        Long id,
+        String name,
+        String description
+) {
+    public static SkillDirectoryResponse fromEntity(SkillEntity skill) {
+        return new SkillDirectoryResponse(skill.getId(), skill.getName(), skill.getDescription());
+    }
+}

--- a/taskpilot-users/src/main/java/com/taskpilot/users/skills/service/SkillService.java
+++ b/taskpilot-users/src/main/java/com/taskpilot/users/skills/service/SkillService.java
@@ -62,7 +62,7 @@ public class SkillService {
 
         SkillEntity skill = skillRepository.findByIdAndIsActiveTrue(request.skillId())
                 .orElseThrow(() -> new BusinessException(HttpStatus.NOT_FOUND.value(),
-                        "Skill does not exist in system directory"));
+                "Skill does not exist in system directory"));
 
         UserSkillId id = new UserSkillId(user.getId(), skill.getId());
         if (userSkillRepository.existsById(id)) {

--- a/taskpilot-users/src/main/java/com/taskpilot/users/skills/service/SkillService.java
+++ b/taskpilot-users/src/main/java/com/taskpilot/users/skills/service/SkillService.java
@@ -9,6 +9,7 @@ import com.taskpilot.users.repository.SkillRepository;
 import com.taskpilot.users.repository.UserRepository;
 import com.taskpilot.users.repository.UserSkillRepository;
 import com.taskpilot.users.skills.dto.AddSkillRequest;
+import com.taskpilot.users.skills.dto.SkillDirectoryResponse;
 import com.taskpilot.users.skills.dto.UpdateSkillRequest;
 import com.taskpilot.users.skills.dto.UserSkillResponse;
 import lombok.RequiredArgsConstructor;
@@ -49,15 +50,19 @@ public class SkillService {
         return UserSkillResponse.fromEntity(us);
     }
 
+    public List<SkillDirectoryResponse> getSkillDirectory() {
+        return skillRepository.findByIsActiveTrueOrderByNameAsc().stream()
+                .map(SkillDirectoryResponse::fromEntity)
+                .collect(Collectors.toList());
+    }
+
     @Transactional
     public void addSkill(AddSkillRequest request) {
         UserEntity user = getCurrentUser();
 
-        SkillEntity skill = skillRepository.findByName(request.name())
-                .orElseGet(() -> {
-                    SkillEntity newSkill = SkillEntity.builder().name(request.name()).build();
-                    return skillRepository.save(newSkill);
-                });
+        SkillEntity skill = skillRepository.findByIdAndIsActiveTrue(request.skillId())
+                .orElseThrow(() -> new BusinessException(HttpStatus.NOT_FOUND.value(),
+                        "Skill does not exist in system directory"));
 
         UserSkillId id = new UserSkillId(user.getId(), skill.getId());
         if (userSkillRepository.existsById(id)) {


### PR DESCRIPTION
This pull request introduces a new "Skill Directory" feature, allowing users to view and select from a list of active system-defined skills rather than entering free-form skill names. It also updates the process for adding skills to require selecting from this directory, improving data consistency and user experience.

**Skill Directory Feature:**

* Added a new endpoint `GET /skills/directory` in `SkillController` to fetch a list of active skills users can add, returning a list of `SkillDirectoryResponse` objects. [[1]](diffhunk://#diff-cf540408931481d4151418ad35297ac54cdad5a07d1a8758083badd77fbefb20R32-R38) [[2]](diffhunk://#diff-197fdc2f9015cedb131ea2b4530ff964d4264573e7592219e4bfab1eb08a8cb9R1-R14)
* Implemented the `SkillDirectoryResponse` DTO and a static `fromEntity` method to map `SkillEntity` objects for API responses.
* Updated `SkillRepository` with `findByIsActiveTrueOrderByNameAsc` and `findByIdAndIsActiveTrue` methods to support fetching and validating active skills.

**Skill Addition Process:**

* Changed `AddSkillRequest` to require a `skillId` (referencing an existing skill in the directory) instead of a free-form skill name.
* Updated `SkillService.addSkill` to validate the provided `skillId` against active skills, throwing a `BusinessException` if the skill does not exist.

**Supporting Changes:**

* Imported new DTOs where needed in controller and service classes. [[1]](diffhunk://#diff-cf540408931481d4151418ad35297ac54cdad5a07d1a8758083badd77fbefb20R5) [[2]](diffhunk://#diff-6916b686ddc66c102a4527c4ad1edafda17143fa01e60ce79a23d5f04f690a6dR12)