### PR TITLE
feat(ai): add project and member CUD tools to TaskPilot AI chatbot

### DIFF
--- a/taskpilot-ai/src/main/java/com/taskpilot/ai/adapter/fake/FakeProjectInsightsAdapter.java
+++ b/taskpilot-ai/src/main/java/com/taskpilot/ai/adapter/fake/FakeProjectInsightsAdapter.java
@@ -3,6 +3,7 @@ package com.taskpilot.ai.adapter.fake;
 import com.taskpilot.contracts.aiquery.dto.ProjectMemberDto;
 import com.taskpilot.contracts.aiquery.dto.ProjectOverviewDto;
 import com.taskpilot.contracts.aiquery.dto.ProjectStatusDto;
+import com.taskpilot.contracts.aiquery.dto.LabelSummaryDto;
 import com.taskpilot.contracts.aiquery.port.out.ProjectInsightsPort;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
@@ -35,5 +36,71 @@ public class FakeProjectInsightsAdapter implements ProjectInsightsPort {
     public List<ProjectMemberDto> getProjectMembers(Long projectId, Long requesterUserId) {
         log.info("[FakeAdapter] getProjectMembers called for projectId={}", projectId);
         return ScenarioFixtures.getProjectMembers(projectId);
+    }
+
+    @Override
+    public ProjectOverviewDto createProject(String name, String description, String startDate, String endDate, Long requesterUserId) {
+        log.info("[FakeAdapter] createProject called for name={}, description={}, startDate={}, endDate={}, userId={}",
+                name, description, startDate, endDate, requesterUserId);
+        return new ProjectOverviewDto(99L, name, description, "ACTIVE", "MANAGER", startDate, endDate, "2026-06-03T12:00:00Z");
+    }
+
+    @Override
+    public ProjectOverviewDto updateProject(Long projectId, String name, String description, String status, String heuristicMode, String workflowMode, String startDate, String endDate, Long requesterUserId) {
+        log.info("[FakeAdapter] updateProject called for projectId={}", projectId);
+        return new ProjectOverviewDto(projectId, name, description, status, "MANAGER", startDate, endDate, "2026-06-03T12:00:00Z");
+    }
+
+    @Override
+    public Object joinProject(String projectCode, Long requesterUserId) {
+        log.info("[FakeAdapter] joinProject called for code={} user={}", projectCode, requesterUserId);
+        return "Joined project successfully";
+    }
+
+    @Override
+    public void leaveProject(Long projectId, Long requesterUserId) {
+        log.info("[FakeAdapter] leaveProject called for projectId={} user={}", projectId, requesterUserId);
+    }
+
+    @Override
+    public void updateMemberRole(Long projectId, Long targetUserId, String role, Long requesterUserId) {
+        log.info("[FakeAdapter] updateMemberRole called for projectId={} target={} role={} user={}", projectId, targetUserId, role, requesterUserId);
+    }
+
+    @Override
+    public void removeMember(Long projectId, Long targetUserId, Long requesterUserId) {
+        log.info("[FakeAdapter] removeMember called for projectId={} target={} user={}", projectId, targetUserId, requesterUserId);
+    }
+
+    @Override
+    public void archiveProject(Long projectId, Long requesterUserId) {
+        log.info("[FakeAdapter] archiveProject called for projectId={} user={}", projectId, requesterUserId);
+    }
+
+    @Override
+    public void restoreProject(Long projectId, Long requesterUserId) {
+        log.info("[FakeAdapter] restoreProject called for projectId={} user={}", projectId, requesterUserId);
+    }
+
+    @Override
+    public void deleteProject(Long projectId, Long requesterUserId) {
+        log.info("[FakeAdapter] deleteProject called for projectId={} user={}", projectId, requesterUserId);
+    }
+
+    @Override
+    public List<LabelSummaryDto> getProjectLabels(Long projectId, Long requesterUserId) {
+        log.info("[FakeAdapter] getProjectLabels called for projectId={} user={}", projectId, requesterUserId);
+        return List.of(new LabelSummaryDto(1L, "backend", "#6366F1"));
+    }
+
+    @Override
+    public LabelSummaryDto createProjectLabel(Long projectId, String name, String color, Long requesterUserId) {
+        log.info("[FakeAdapter] createProjectLabel called for projectId={} name={} user={}", projectId, name, requesterUserId);
+        return new LabelSummaryDto(99L, name, color != null ? color : "#6366F1");
+    }
+
+    @Override
+    public void deleteProjectLabel(Long projectId, Long labelId, Long requesterUserId) {
+        log.info("[FakeAdapter] deleteProjectLabel called for projectId={} labelId={} user={}", projectId, labelId, requesterUserId);
     }
 }

--- a/taskpilot-ai/src/main/java/com/taskpilot/ai/adapter/fake/FakeTaskCommandAdapter.java
+++ b/taskpilot-ai/src/main/java/com/taskpilot/ai/adapter/fake/FakeTaskCommandAdapter.java
@@ -69,11 +69,33 @@ public class FakeTaskCommandAdapter implements TaskCommandPort {
     }
 
     @Override
-    public TaskSummaryDto createTask(Long projectId, String title, String description, String priority,
-            Long parentTaskId, Long sprintId, Integer difficultyLevel, Long assigneeId, String dueDate,
-            Long requesterUserId) {
+    public TaskSummaryDto updateTask(Long taskId, String title, String description, String status, String priority,
+            Float position, List<Long> labelIds, Integer difficultyLevel, List<Long> requiredSkillIds,
+            Long assigneeId, String startDate, String dueDate, Long requesterUserId) {
+        log.info("[FakeAdapter] updateTask called for taskId={}", taskId);
+        return new TaskSummaryDto(taskId, 1L, null, null, title != null ? title : "Sample task",
+                description, status != null ? status : "TODO", priority != null ? priority : "MEDIUM",
+                difficultyLevel, assigneeId, null, dueDate, null, null);
+    }
+
+    @Override
+    public TaskSummaryDto createTask(Long projectId, String title, String description, String priority, Float position,
+            Long parentTaskId, Long sprintId, Integer difficultyLevel, List<Long> labelIds,
+            List<Long> requiredSkillIds, Long assigneeId, String startDate, String dueDate, Long requesterUserId) {
         log.info("[FakeAdapter] createTask called for projectId={} title={}", projectId, title);
         return new TaskSummaryDto(999L, projectId, parentTaskId, sprintId, title, description, "TODO",
                 priority != null ? priority : "MEDIUM", difficultyLevel, assigneeId, null, dueDate, null, null);
+    }
+
+    @Override
+    public void deleteTask(Long taskId, Long requesterUserId) {
+        log.info("[FakeAdapter] deleteTask called for taskId={}", taskId);
+    }
+
+    @Override
+    public TaskSummaryDto moveTaskKanban(Long taskId, String status, Float position, Long requesterUserId) {
+        log.info("[FakeAdapter] moveTaskKanban called for taskId={} status={} position={}", taskId, status, position);
+        return new TaskSummaryDto(taskId, 1L, null, null, "Sample task", null, status, "MEDIUM",
+                3, null, null, null, null, null);
     }
 }

--- a/taskpilot-ai/src/main/java/com/taskpilot/ai/tools/TaskPilotAiTools.java
+++ b/taskpilot-ai/src/main/java/com/taskpilot/ai/tools/TaskPilotAiTools.java
@@ -92,6 +92,16 @@ public class TaskPilotAiTools {
     }
 
     @Tool("""
+            Use this tool to fetch labels configured for a project.
+            Provide the project ID. It returns label IDs, names, and colors.
+            """)
+    public List<LabelSummaryDto> getProjectLabels(@P("The ID of the project") Long projectId) {
+        log.info("[AiTool] getProjectLabels called for project {}", projectId);
+        Long userId = ToolExecutionContext.requireUserId();
+        return projectInsightsPort.getProjectLabels(projectId, userId);
+    }
+
+    @Tool("""
             Use this tool when the user asks for workload details of a specific member.
             Typical intents include: "member workload", "load cua thanh vien", "dang lam bao nhieu task".
             Provide the member ID. This tool returns open tasks, overdue tasks, and estimated hours.
@@ -477,6 +487,77 @@ public class TaskPilotAiTools {
     }
 
     @Tool("""
+            Use this tool to create a comment on a task, or reply to a task comment.
+            Provide task ID and content. parentCommentId is optional for replies; mentionedUserIds is optional.
+            This tool performs a real database modification and requires final user confirmation.
+            """)
+    public Object createTaskComment(
+            @P("The ID of the task") Long taskId,
+            @P("Comment content") String content,
+            @P("Optional parent comment ID when replying") Long parentCommentId,
+            @P("Optional mentioned user IDs") List<Long> mentionedUserIds) {
+        log.info("[AiTool] createTaskComment called for task {}", taskId);
+        Long userId = ToolExecutionContext.requireUserId();
+        Long sessionId = ToolExecutionContext.requireSessionId();
+        return pendingAiActionService.create(
+                userId,
+                sessionId,
+                "createTaskComment",
+                "Create comment on task " + taskId,
+                args("taskId", taskId, "content", content, "parentCommentId", parentCommentId,
+                        "mentionedUserIds", mentionedUserIds),
+                null,
+                () -> taskCommentQueryPort.createTaskComment(taskId, content, parentCommentId, mentionedUserIds,
+                        userId));
+    }
+
+    @Tool("""
+            Use this tool to update an existing task comment authored by the current user.
+            Provide task ID, comment ID, new content, and optional mentioned user IDs.
+            This tool performs a real database modification and requires final user confirmation.
+            """)
+    public Object updateTaskComment(
+            @P("The ID of the task") Long taskId,
+            @P("The ID of the comment") Long commentId,
+            @P("Updated comment content") String content,
+            @P("Optional mentioned user IDs") List<Long> mentionedUserIds) {
+        log.info("[AiTool] updateTaskComment called for task {} comment {}", taskId, commentId);
+        Long userId = ToolExecutionContext.requireUserId();
+        Long sessionId = ToolExecutionContext.requireSessionId();
+        return pendingAiActionService.create(
+                userId,
+                sessionId,
+                "updateTaskComment",
+                "Update comment " + commentId + " on task " + taskId,
+                args("taskId", taskId, "commentId", commentId, "content", content,
+                        "mentionedUserIds", mentionedUserIds),
+                null,
+                () -> taskCommentQueryPort.updateTaskComment(taskId, commentId, content, mentionedUserIds,
+                        userId));
+    }
+
+    @Tool("""
+            Use this tool to delete a task comment. Authors and project managers may delete comments according
+            to project permissions.
+            This tool performs a real database modification and requires final user confirmation.
+            """)
+    public Object deleteTaskComment(
+            @P("The ID of the task") Long taskId,
+            @P("The ID of the comment") Long commentId) {
+        log.info("[AiTool] deleteTaskComment called for task {} comment {}", taskId, commentId);
+        Long userId = ToolExecutionContext.requireUserId();
+        Long sessionId = ToolExecutionContext.requireSessionId();
+        return pendingAiActionService.create(
+                userId,
+                sessionId,
+                "deleteTaskComment",
+                "Delete comment " + commentId + " on task " + taskId,
+                args("taskId", taskId, "commentId", commentId),
+                null,
+                () -> taskCommentQueryPort.deleteTaskComment(taskId, commentId, userId));
+    }
+
+    @Tool("""
             Use this tool to update the status of a task (e.g. TODO, IN_PROGRESS, REVIEW, DONE).
             Provide the task ID and the new status.
             This tool updates real task data and should only be used when the user explicitly asks for a status change.
@@ -498,6 +579,86 @@ public class TaskPilotAiTools {
     }
 
     @Tool("""
+            Use this tool to update task fields such as title, description, status, priority, position, labels,
+            difficulty, required skills, assignee, start date, or due date.
+            For unchanged fields pass null. Dates should be ISO-8601 instants or YYYY-MM-DD.
+            This tool performs a real database modification and requires final user confirmation.
+            """)
+    public Object updateTask(
+            @P("The ID of the task") Long taskId,
+            @P("Optional title") String title,
+            @P("Optional description") String description,
+            @P("Optional status (TODO, IN_PROGRESS, REVIEW, DONE)") String status,
+            @P("Optional priority (LOW, MEDIUM, HIGH, URGENT)") String priority,
+            @P("Optional kanban position") Float position,
+            @P("Optional full replacement label ID list") List<Long> labelIds,
+            @P("Optional difficulty 1-10") Integer difficultyLevel,
+            @P("Optional full replacement required skill ID list") List<Long> requiredSkillIds,
+            @P("Optional assignee user ID") Long assigneeId,
+            @P("Optional start date as ISO-8601 instant or YYYY-MM-DD") String startDate,
+            @P("Optional due date as ISO-8601 instant or YYYY-MM-DD") String dueDate) {
+        log.info("[AiTool] updateTask called for task {}", taskId);
+        Long userId = ToolExecutionContext.requireUserId();
+        Long sessionId = ToolExecutionContext.requireSessionId();
+        return pendingAiActionService.create(
+                userId,
+                sessionId,
+                "updateTask",
+                "Update task " + taskId,
+                args("taskId", taskId, "title", title, "description", description, "status", status,
+                        "priority", priority, "position", position, "labelIds", labelIds,
+                        "difficultyLevel", difficultyLevel, "requiredSkillIds", requiredSkillIds,
+                        "assigneeId", assigneeId, "startDate", startDate, "dueDate", dueDate),
+                null,
+                () -> taskCommandPort.updateTask(taskId, title, description, status, priority, position, labelIds,
+                        difficultyLevel, requiredSkillIds, assigneeId, startDate, dueDate, userId));
+    }
+
+    @Tool("""
+            Use this tool to delete a task. The backend enforces whether the current user can delete it
+            (reporter or project manager).
+            This tool performs a real database modification and requires final user confirmation.
+            """)
+    public Object deleteTask(@P("The ID of the task to delete") Long taskId) {
+        log.info("[AiTool] deleteTask called for task {}", taskId);
+        Long userId = ToolExecutionContext.requireUserId();
+        Long sessionId = ToolExecutionContext.requireSessionId();
+        return pendingAiActionService.create(
+                userId,
+                sessionId,
+                "deleteTask",
+                "Delete task " + taskId,
+                args("taskId", taskId),
+                null,
+                () -> {
+                    taskCommandPort.deleteTask(taskId, userId);
+                    return "Task deleted successfully";
+                });
+    }
+
+    @Tool("""
+            Use this tool to move a task on the kanban board by setting status and position.
+            Provide the task ID, target status, and target position.
+            This tool performs a real database modification and requires final user confirmation.
+            """)
+    public Object moveTaskKanban(
+            @P("The ID of the task") Long taskId,
+            @P("Target status (TODO, IN_PROGRESS, REVIEW, DONE)") String status,
+            @P("Target kanban position") Float position) {
+        log.info("[AiTool] moveTaskKanban called for task {} -> {} @ {}", taskId, status, position);
+        Long userId = ToolExecutionContext.requireUserId();
+        Long sessionId = ToolExecutionContext.requireSessionId();
+        return pendingAiActionService.create(
+                userId,
+                sessionId,
+                "moveTaskKanban",
+                "Move task " + taskId + " to " + status,
+                args("taskId", taskId, "status", status, "position", position),
+                null,
+                () -> taskCommandPort.moveTaskKanban(taskId, status, position, userId));
+    }
+
+    @Tool("""
             Use this tool to fetch all sprints belonging to a specific project.
             Provide the project ID.
             """)
@@ -508,9 +669,275 @@ public class TaskPilotAiTools {
     }
 
     @Tool("""
+            Use this tool to create a label in a project. Only project managers can perform this.
+            Provide project ID, label name, and optional hex color (#RRGGBB).
+            This tool performs a real database modification and requires final user confirmation.
+            """)
+    public Object createProjectLabel(
+            @P("The ID of the project") Long projectId,
+            @P("Label name") String name,
+            @P("Optional hex color, e.g. #6366F1") String color) {
+        log.info("[AiTool] createProjectLabel called for project {}", projectId);
+        Long userId = ToolExecutionContext.requireUserId();
+        Long sessionId = ToolExecutionContext.requireSessionId();
+        return pendingAiActionService.create(
+                userId,
+                sessionId,
+                "createProjectLabel",
+                "Create label \"" + name + "\" in project " + projectId,
+                args("projectId", projectId, "name", name, "color", color),
+                null,
+                () -> projectInsightsPort.createProjectLabel(projectId, name, color, userId));
+    }
+
+    @Tool("""
+            Use this tool to delete a project label. Only project managers can perform this.
+            Provide project ID and label ID.
+            This tool performs a real database modification and requires final user confirmation.
+            """)
+    public Object deleteProjectLabel(
+            @P("The ID of the project") Long projectId,
+            @P("The ID of the label") Long labelId) {
+        log.info("[AiTool] deleteProjectLabel called for project {} label {}", projectId, labelId);
+        Long userId = ToolExecutionContext.requireUserId();
+        Long sessionId = ToolExecutionContext.requireSessionId();
+        return pendingAiActionService.create(
+                userId,
+                sessionId,
+                "deleteProjectLabel",
+                "Delete label " + labelId + " from project " + projectId,
+                args("projectId", projectId, "labelId", labelId),
+                null,
+                () -> {
+                    projectInsightsPort.deleteProjectLabel(projectId, labelId, userId);
+                    return "Label deleted successfully";
+                });
+    }
+
+    @Tool("""
+            Use this tool to create a new project.
+            Provide the project name. Optional fields include description, startDate (YYYY-MM-DD),
+            and endDate (YYYY-MM-DD).
+            This tool creates real database data and requires final user confirmation.
+            """)
+    public Object createProject(
+            @P("Name of the project") String projectName,
+            @P("Optional description of the project") String description,
+            @P("Optional start date in YYYY-MM-DD format") String startDate,
+            @P("Optional end date in YYYY-MM-DD format") String endDate) {
+        log.info("[AiTool] createProject called with name={}", projectName);
+        Long userId = ToolExecutionContext.requireUserId();
+        Long sessionId = ToolExecutionContext.requireSessionId();
+
+        return pendingAiActionService.create(
+                userId,
+                sessionId,
+                "createProject",
+                "Create new project \"" + projectName + "\"",
+                args("projectName", projectName, "description", description, "startDate", startDate, "endDate", endDate),
+                null,
+                () -> projectInsightsPort.createProject(projectName, description, startDate, endDate, userId));
+    }
+
+    @Tool("""
+            Use this tool to update details of an existing project.
+            Provide the project ID. Optional fields include name, description, status (ACTIVE, COMPLETED, ARCHIVED),
+            heuristicMode (BALANCED, SKILL_FIT_ONLY, WORKLOAD_ONLY), workflowMode (STANDARD, SCRUM, KANBAN),
+            startDate (YYYY-MM-DD), and endDate (YYYY-MM-DD).
+            This tool performs a real database modification and requires final user confirmation.
+            """)
+    public Object updateProject(
+            @P("The ID of the project to update") Long projectId,
+            @P("Optional name of the project") String name,
+            @P("Optional description") String description,
+            @P("Optional status (ACTIVE, COMPLETED, ARCHIVED)") String status,
+            @P("Optional heuristic mode (BALANCED, SKILL_FIT_ONLY, WORKLOAD_ONLY)") String heuristicMode,
+            @P("Optional workflow mode (STANDARD, SCRUM, KANBAN)") String workflowMode,
+            @P("Optional start date in YYYY-MM-DD format") String startDate,
+            @P("Optional end date in YYYY-MM-DD format") String endDate) {
+        log.info("[AiTool] updateProject called for project {}", projectId);
+        Long userId = ToolExecutionContext.requireUserId();
+        Long sessionId = ToolExecutionContext.requireSessionId();
+
+        return pendingAiActionService.create(
+                userId,
+                sessionId,
+                "updateProject",
+                "Update project details for project ID " + projectId,
+                args("projectId", projectId, "name", name, "description", description, "status", status,
+                        "heuristicMode", heuristicMode, "workflowMode", workflowMode, "startDate", startDate, "endDate", endDate),
+                null,
+                () -> projectInsightsPort.updateProject(projectId, name, description, status, heuristicMode, workflowMode, startDate, endDate, userId));
+    }
+
+    @Tool("""
+            Use this tool to join an existing project using an invitation code.
+            Provide the projectCode (invitation code).
+            This tool performs a real database modification and requires final user confirmation.
+            """)
+    public Object joinProject(@P("The invitation project code") String projectCode) {
+        log.info("[AiTool] joinProject called with code={}", projectCode);
+        Long userId = ToolExecutionContext.requireUserId();
+        Long sessionId = ToolExecutionContext.requireSessionId();
+
+        return pendingAiActionService.create(
+                userId,
+                sessionId,
+                "joinProject",
+                "Join project with code \"" + projectCode + "\"",
+                args("projectCode", projectCode),
+                null,
+                () -> projectInsightsPort.joinProject(projectCode, userId));
+    }
+
+    @Tool("""
+            Use this tool to leave an existing project (remove membership).
+            Provide the project ID.
+            This tool performs a real database modification and requires final user confirmation.
+            """)
+    public Object leaveProject(@P("The ID of the project to leave") Long projectId) {
+        log.info("[AiTool] leaveProject called for project {}", projectId);
+        Long userId = ToolExecutionContext.requireUserId();
+        Long sessionId = ToolExecutionContext.requireSessionId();
+
+        return pendingAiActionService.create(
+                userId,
+                sessionId,
+                "leaveProject",
+                "Leave project ID " + projectId,
+                args("projectId", projectId),
+                null,
+                () -> {
+                    projectInsightsPort.leaveProject(projectId, userId);
+                    return "Left project successfully";
+                });
+    }
+
+    @Tool("""
+            Use this tool to update the role of a project member. Only project managers can perform this.
+            Provide the project ID, target user ID, and new role (MANAGER, MEMBER).
+            This tool performs a real database modification and requires final user confirmation.
+            """)
+    public Object updateMemberRole(
+            @P("The ID of the project") Long projectId,
+            @P("The ID of the target user to update role") Long targetUserId,
+            @P("The new role (MANAGER, MEMBER)") String role) {
+        log.info("[AiTool] updateMemberRole called for project {} target {} role {}", projectId, targetUserId, role);
+        Long userId = ToolExecutionContext.requireUserId();
+        Long sessionId = ToolExecutionContext.requireSessionId();
+
+        return pendingAiActionService.create(
+                userId,
+                sessionId,
+                "updateMemberRole",
+                "Update member role of user " + targetUserId + " to " + role + " in project " + projectId,
+                args("projectId", projectId, "targetUserId", targetUserId, "role", role),
+                null,
+                () -> {
+                    projectInsightsPort.updateMemberRole(projectId, targetUserId, role, userId);
+                    return "Member role updated successfully";
+                });
+    }
+
+    @Tool("""
+            Use this tool to remove a member from a project. Only project managers can perform this.
+            Provide the project ID and target user ID to remove.
+            This tool performs a real database modification and requires final user confirmation.
+            """)
+    public Object removeMember(
+            @P("The ID of the project") Long projectId,
+            @P("The ID of the target user to remove") Long targetUserId) {
+        log.info("[AiTool] removeMember called for project {} target {}", projectId, targetUserId);
+        Long userId = ToolExecutionContext.requireUserId();
+        Long sessionId = ToolExecutionContext.requireSessionId();
+
+        return pendingAiActionService.create(
+                userId,
+                sessionId,
+                "removeMember",
+                "Remove member " + targetUserId + " from project " + projectId,
+                args("projectId", projectId, "targetUserId", targetUserId),
+                null,
+                () -> {
+                    projectInsightsPort.removeMember(projectId, targetUserId, userId);
+                    return "Member removed successfully";
+                });
+    }
+
+    @Tool("""
+            Use this tool to archive a project to make it read-only. Only project managers can perform this.
+            Provide the project ID.
+            This tool performs a real database modification and requires final user confirmation.
+            """)
+    public Object archiveProject(@P("The ID of the project to archive") Long projectId) {
+        log.info("[AiTool] archiveProject called for project {}", projectId);
+        Long userId = ToolExecutionContext.requireUserId();
+        Long sessionId = ToolExecutionContext.requireSessionId();
+
+        return pendingAiActionService.create(
+                userId,
+                sessionId,
+                "archiveProject",
+                "Archive project ID " + projectId,
+                args("projectId", projectId),
+                null,
+                () -> {
+                    projectInsightsPort.archiveProject(projectId, userId);
+                    return "Project archived successfully";
+                });
+    }
+
+    @Tool("""
+            Use this tool to restore an archived project to active status. Only project managers can perform this.
+            Provide the project ID.
+            This tool performs a real database modification and requires final user confirmation.
+            """)
+    public Object restoreProject(@P("The ID of the project to restore") Long projectId) {
+        log.info("[AiTool] restoreProject called for project {}", projectId);
+        Long userId = ToolExecutionContext.requireUserId();
+        Long sessionId = ToolExecutionContext.requireSessionId();
+
+        return pendingAiActionService.create(
+                userId,
+                sessionId,
+                "restoreProject",
+                "Restore project ID " + projectId,
+                args("projectId", projectId),
+                null,
+                () -> {
+                    projectInsightsPort.restoreProject(projectId, userId);
+                    return "Project restored successfully";
+                });
+    }
+
+    @Tool("""
+            Use this tool to permanently delete a project and all its data. Only project managers can perform this.
+            Provide the project ID.
+            This tool performs a real database modification and requires final user confirmation.
+            """)
+    public Object deleteProject(@P("The ID of the project to delete") Long projectId) {
+        log.info("[AiTool] deleteProject called for project {}", projectId);
+        Long userId = ToolExecutionContext.requireUserId();
+        Long sessionId = ToolExecutionContext.requireSessionId();
+
+        return pendingAiActionService.create(
+                userId,
+                sessionId,
+                "deleteProject",
+                "Permanently delete project ID " + projectId,
+                args("projectId", projectId),
+                null,
+                () -> {
+                    projectInsightsPort.deleteProject(projectId, userId);
+                    return "Project deleted successfully";
+                });
+    }
+
+    @Tool("""
             Use this tool to create a new task in a project.
             Provide project ID and title. Optional fields include description, priority, parent task ID,
-            sprint ID, difficulty, assignee ID, and dueDate as ISO-8601 or YYYY-MM-DD.
+            sprint ID, position, label IDs, required skill IDs, difficulty, assignee ID, startDate, and dueDate.
+            Dates should be ISO-8601 instants or YYYY-MM-DD.
             This tool creates real task data and should only be used when the user explicitly asks to create a task.
             """)
     public Object createTask(
@@ -518,10 +945,14 @@ public class TaskPilotAiTools {
             @P("Title of the task") String title,
             @P("Priority (LOW, MEDIUM, HIGH, URGENT)") String priority,
             @P("Optional description") String description,
+            @P("Optional kanban position") Float position,
             @P("Optional parent task ID") Long parentTaskId,
             @P("Optional sprint ID") Long sprintId,
             @P("Optional task difficulty 1-10") Integer difficultyLevel,
+            @P("Optional label ID list") List<Long> labelIds,
+            @P("Optional required skill ID list") List<Long> requiredSkillIds,
             @P("Optional assignee user ID") Long assigneeId,
+            @P("Optional start date as ISO-8601 instant or YYYY-MM-DD") String startDate,
             @P("Optional due date as ISO-8601 instant or YYYY-MM-DD") String dueDate) {
         log.info("[AiTool] createTask called for project {}", projectId);
         Long userId = ToolExecutionContext.requireUserId();
@@ -532,11 +963,14 @@ public class TaskPilotAiTools {
                 "createTask",
                 "Create task \"" + title + "\" in project " + projectId,
                 args("projectId", projectId, "title", title, "priority", priority, "description", description,
-                        "parentTaskId", parentTaskId, "sprintId", sprintId, "difficultyLevel", difficultyLevel,
-                        "assigneeId", assigneeId, "dueDate", dueDate),
+                        "position", position, "parentTaskId", parentTaskId, "sprintId", sprintId,
+                        "difficultyLevel", difficultyLevel, "labelIds", labelIds,
+                        "requiredSkillIds", requiredSkillIds, "assigneeId", assigneeId,
+                        "startDate", startDate, "dueDate", dueDate),
                 null,
-                () -> taskCommandPort.createTask(projectId, title, description, priority, parentTaskId, sprintId,
-                        difficultyLevel, assigneeId, dueDate, userId));
+                () -> taskCommandPort.createTask(projectId, title, description, priority, position, parentTaskId,
+                        sprintId, difficultyLevel, labelIds, requiredSkillIds, assigneeId, startDate, dueDate,
+                        userId));
     }
 
     @Tool("""
@@ -587,6 +1021,56 @@ public class TaskPilotAiTools {
                 args("projectId", projectId, "name", name, "startDate", startDate, "endDate", endDate, "goal", goal),
                 null,
                 () -> sprintQueryPort.createSprint(projectId, name, startDate, endDate, goal, userId));
+    }
+
+    @Tool("""
+            Use this tool to update a planning or active sprint's details.
+            Provide project ID and sprint ID. Optional fields include name, startDate, endDate, and goal.
+            This tool performs a real database modification and requires final user confirmation.
+            """)
+    public Object updateSprint(
+            @P("The project ID") Long projectId,
+            @P("The ID of the sprint") Long sprintId,
+            @P("Optional sprint name") String name,
+            @P("Optional start date in YYYY-MM-DD format") String startDate,
+            @P("Optional end date in YYYY-MM-DD format") String endDate,
+            @P("Optional sprint goal") String goal) {
+        log.info("[AiTool] updateSprint called for sprint {}", sprintId);
+        Long userId = ToolExecutionContext.requireUserId();
+        Long sessionId = ToolExecutionContext.requireSessionId();
+        return pendingAiActionService.create(
+                userId,
+                sessionId,
+                "updateSprint",
+                "Update sprint " + sprintId + " in project " + projectId,
+                args("projectId", projectId, "sprintId", sprintId, "name", name, "startDate", startDate,
+                        "endDate", endDate, "goal", goal),
+                null,
+                () -> sprintQueryPort.updateSprint(projectId, sprintId, name, startDate, endDate, goal, userId));
+    }
+
+    @Tool("""
+            Use this tool to delete a planning sprint. Only project managers can perform this.
+            Provide project ID and sprint ID.
+            This tool performs a real database modification and requires final user confirmation.
+            """)
+    public Object deleteSprint(
+            @P("The project ID") Long projectId,
+            @P("The ID of the sprint") Long sprintId) {
+        log.info("[AiTool] deleteSprint called for sprint {}", sprintId);
+        Long userId = ToolExecutionContext.requireUserId();
+        Long sessionId = ToolExecutionContext.requireSessionId();
+        return pendingAiActionService.create(
+                userId,
+                sessionId,
+                "deleteSprint",
+                "Delete sprint " + sprintId + " in project " + projectId,
+                args("projectId", projectId, "sprintId", sprintId),
+                null,
+                () -> {
+                    sprintQueryPort.deleteSprint(projectId, sprintId, userId);
+                    return "Sprint deleted successfully";
+                });
     }
 
     @Tool("""

--- a/taskpilot-ai/src/test/java/com/taskpilot/ai/tools/TaskPilotAiToolsHumanInLoopTest.java
+++ b/taskpilot-ai/src/test/java/com/taskpilot/ai/tools/TaskPilotAiToolsHumanInLoopTest.java
@@ -228,17 +228,20 @@ class TaskPilotAiToolsHumanInLoopTest {
     @Test
     void createTaskWaitsForHumanConfirmationBeforeWriting() {
         TaskSummaryDto created = task(90L, "TODO");
-        when(taskCommandPort.createTask(8L, "AI test", "desc", "MEDIUM", null, null, 3, null, null, USER_ID))
+        when(taskCommandPort.createTask(8L, "AI test", "desc", "MEDIUM", null, null, null, 3, null, null,
+                null, null, null, USER_ID))
                 .thenReturn(created);
 
         ConfirmationRequiredDto pending = assertPending(
-                tools.createTask(8L, "AI test", "MEDIUM", "desc", null, null, 3, null, null),
+                tools.createTask(8L, "AI test", "MEDIUM", "desc", null, null, null, 3, null, null, null, null, null),
                 "createTask");
 
-        verify(taskCommandPort, never()).createTask(any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+        verify(taskCommandPort, never()).createTask(any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any());
 
         assertEquals(created, confirm(pending.actionId()));
-        verify(taskCommandPort).createTask(8L, "AI test", "desc", "MEDIUM", null, null, 3, null, null, USER_ID);
+        verify(taskCommandPort).createTask(8L, "AI test", "desc", "MEDIUM", null, null, null, 3, null, null,
+                null, null, null, USER_ID);
     }
 
     @Test
@@ -272,6 +275,33 @@ class TaskPilotAiToolsHumanInLoopTest {
         verify(sprintQueryPort).startSprint(8L, 31L, USER_ID);
         verify(sprintQueryPort).completeSprint(8L, 31L, USER_ID);
         verify(sprintQueryPort).assignTaskToSprint(75L, 31L, USER_ID);
+    }
+
+    @Test
+    void additionalProjectWriteToolsWaitForHumanConfirmationBeforeWriting() {
+        assertPending(tools.updateTask(75L, "New title", "desc", "REVIEW", "HIGH", 2f,
+                List.of(4L), 5, List.of(7L), 18L, "2026-06-01", "2026-06-08"), "updateTask");
+        assertPending(tools.deleteTask(75L), "deleteTask");
+        assertPending(tools.moveTaskKanban(75L, "DONE", 3f), "moveTaskKanban");
+        assertPending(tools.createTaskComment(75L, "Looks good", null, List.of(18L)), "createTaskComment");
+        assertPending(tools.updateTaskComment(75L, 30L, "Updated", List.of()), "updateTaskComment");
+        assertPending(tools.deleteTaskComment(75L, 30L), "deleteTaskComment");
+        assertPending(tools.createProjectLabel(8L, "urgent", "#EF4444"), "createProjectLabel");
+        assertPending(tools.deleteProjectLabel(8L, 4L), "deleteProjectLabel");
+        assertPending(tools.updateSprint(8L, 31L, "Sprint renamed", null, null, "new goal"), "updateSprint");
+        assertPending(tools.deleteSprint(8L, 31L), "deleteSprint");
+
+        verify(taskCommandPort, never()).updateTask(any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any());
+        verify(taskCommandPort, never()).deleteTask(any(), any());
+        verify(taskCommandPort, never()).moveTaskKanban(any(), any(), any(), any());
+        verify(taskCommentQueryPort, never()).createTaskComment(any(), any(), any(), any(), any());
+        verify(taskCommentQueryPort, never()).updateTaskComment(any(), any(), any(), any(), any());
+        verify(taskCommentQueryPort, never()).deleteTaskComment(any(), any(), any());
+        verify(projectInsightsPort, never()).createProjectLabel(any(), any(), any(), any());
+        verify(projectInsightsPort, never()).deleteProjectLabel(any(), any(), any());
+        verify(sprintQueryPort, never()).updateSprint(any(), any(), any(), any(), any(), any(), any());
+        verify(sprintQueryPort, never()).deleteSprint(any(), any(), any());
     }
 
     private ConfirmationRequiredDto assertPending(Object result, String toolName) {

--- a/taskpilot-contracts/src/main/java/com/taskpilot/contracts/aiquery/dto/LabelSummaryDto.java
+++ b/taskpilot-contracts/src/main/java/com/taskpilot/contracts/aiquery/dto/LabelSummaryDto.java
@@ -1,0 +1,4 @@
+package com.taskpilot.contracts.aiquery.dto;
+
+public record LabelSummaryDto(Long id, String name, String color) {
+}

--- a/taskpilot-contracts/src/main/java/com/taskpilot/contracts/aiquery/port/out/ProjectInsightsPort.java
+++ b/taskpilot-contracts/src/main/java/com/taskpilot/contracts/aiquery/port/out/ProjectInsightsPort.java
@@ -3,6 +3,7 @@ package com.taskpilot.contracts.aiquery.port.out;
 import com.taskpilot.contracts.aiquery.dto.ProjectMemberDto;
 import com.taskpilot.contracts.aiquery.dto.ProjectOverviewDto;
 import com.taskpilot.contracts.aiquery.dto.ProjectStatusDto;
+import com.taskpilot.contracts.aiquery.dto.LabelSummaryDto;
 
 import java.util.List;
 
@@ -10,4 +11,16 @@ public interface ProjectInsightsPort {
     List<ProjectOverviewDto> getMyProjects(Long requesterUserId);
     ProjectStatusDto getProjectStatus(Long projectId, Long requesterUserId);
     List<ProjectMemberDto> getProjectMembers(Long projectId, Long requesterUserId);
+    ProjectOverviewDto createProject(String name, String description, String startDate, String endDate, Long requesterUserId);
+    ProjectOverviewDto updateProject(Long projectId, String name, String description, String status, String heuristicMode, String workflowMode, String startDate, String endDate, Long requesterUserId);
+    Object joinProject(String projectCode, Long requesterUserId);
+    void leaveProject(Long projectId, Long requesterUserId);
+    void updateMemberRole(Long projectId, Long targetUserId, String role, Long requesterUserId);
+    void removeMember(Long projectId, Long targetUserId, Long requesterUserId);
+    void archiveProject(Long projectId, Long requesterUserId);
+    void restoreProject(Long projectId, Long requesterUserId);
+    void deleteProject(Long projectId, Long requesterUserId);
+    List<LabelSummaryDto> getProjectLabels(Long projectId, Long requesterUserId);
+    LabelSummaryDto createProjectLabel(Long projectId, String name, String color, Long requesterUserId);
+    void deleteProjectLabel(Long projectId, Long labelId, Long requesterUserId);
 }

--- a/taskpilot-contracts/src/main/java/com/taskpilot/contracts/aiquery/port/out/SprintQueryPort.java
+++ b/taskpilot-contracts/src/main/java/com/taskpilot/contracts/aiquery/port/out/SprintQueryPort.java
@@ -13,6 +13,9 @@ public interface SprintQueryPort {
 
     // Write Tools
     SprintSummaryDto createSprint(Long projectId, String name, String startDate, String endDate, String goal, Long requesterUserId);
+    SprintSummaryDto updateSprint(Long projectId, Long sprintId, String name, String startDate, String endDate, String goal,
+            Long requesterUserId);
+    void deleteSprint(Long projectId, Long sprintId, Long requesterUserId);
     SprintSummaryDto startSprint(Long projectId, Long sprintId, Long requesterUserId);
     SprintSummaryDto completeSprint(Long projectId, Long sprintId, Long requesterUserId);
     Object assignTaskToSprint(Long taskId, Long sprintId, Long requesterUserId);

--- a/taskpilot-contracts/src/main/java/com/taskpilot/contracts/aiquery/port/out/TaskCommandPort.java
+++ b/taskpilot-contracts/src/main/java/com/taskpilot/contracts/aiquery/port/out/TaskCommandPort.java
@@ -15,6 +15,12 @@ public interface TaskCommandPort {
     TaskAssignmentResultDto assignTaskToMember(Long taskId, Long memberId, String reason, Long requesterUserId,
             boolean simulate);
     TaskSummaryDto updateTaskStatus(Long taskId, String status, Long requesterUserId);
-    TaskSummaryDto createTask(Long projectId, String title, String description, String priority, Long parentTaskId,
-            Long sprintId, Integer difficultyLevel, Long assigneeId, String dueDate, Long requesterUserId);
+    TaskSummaryDto updateTask(Long taskId, String title, String description, String status, String priority,
+            Float position, List<Long> labelIds, Integer difficultyLevel, List<Long> requiredSkillIds,
+            Long assigneeId, String startDate, String dueDate, Long requesterUserId);
+    TaskSummaryDto createTask(Long projectId, String title, String description, String priority, Float position,
+            Long parentTaskId, Long sprintId, Integer difficultyLevel, List<Long> labelIds,
+            List<Long> requiredSkillIds, Long assigneeId, String startDate, String dueDate, Long requesterUserId);
+    void deleteTask(Long taskId, Long requesterUserId);
+    TaskSummaryDto moveTaskKanban(Long taskId, String status, Float position, Long requesterUserId);
 }

--- a/taskpilot-contracts/src/main/java/com/taskpilot/contracts/aiquery/port/out/TaskCommentQueryPort.java
+++ b/taskpilot-contracts/src/main/java/com/taskpilot/contracts/aiquery/port/out/TaskCommentQueryPort.java
@@ -6,4 +6,9 @@ import com.taskpilot.contracts.aiquery.dto.TaskCommentSummaryDto;
 
 public interface TaskCommentQueryPort {
     List<TaskCommentSummaryDto> getTaskComments(Long taskId, Long requesterUserId);
+    TaskCommentSummaryDto createTaskComment(Long taskId, String content, Long parentCommentId,
+            List<Long> mentionedUserIds, Long requesterUserId);
+    TaskCommentSummaryDto updateTaskComment(Long taskId, Long commentId, String content,
+            List<Long> mentionedUserIds, Long requesterUserId);
+    TaskCommentSummaryDto deleteTaskComment(Long taskId, Long commentId, Long requesterUserId);
 }

--- a/taskpilot-projects/src/main/java/com/taskpilot/projects/aiquery/adapter/out/AiQueryModuleAdapter.java
+++ b/taskpilot-projects/src/main/java/com/taskpilot/projects/aiquery/adapter/out/AiQueryModuleAdapter.java
@@ -1,6 +1,7 @@
 package com.taskpilot.projects.aiquery.adapter.out;
 
 import com.taskpilot.contracts.aiquery.dto.MemberWorkloadDto;
+import com.taskpilot.contracts.aiquery.dto.LabelSummaryDto;
 import com.taskpilot.contracts.aiquery.dto.ProjectMemberDto;
 import com.taskpilot.contracts.aiquery.dto.ProjectOverviewDto;
 import com.taskpilot.contracts.aiquery.dto.ProjectStatusDto;
@@ -31,9 +32,23 @@ import com.taskpilot.projects.common.repository.SprintRepository;
 import com.taskpilot.projects.common.repository.TaskRepository;
 import com.taskpilot.projects.common.repository.TaskRequiredSkillRepository;
 import com.taskpilot.projects.sprints.service.SprintService;
+import com.taskpilot.projects.tasks.service.LabelService;
 import com.taskpilot.projects.tasks.service.TaskService;
 import com.taskpilot.projects.sprints.dto.CreateSprintRequest;
+import com.taskpilot.projects.sprints.dto.UpdateSprintRequest;
+import com.taskpilot.projects.tasks.dto.CreateLabelRequest;
+import com.taskpilot.projects.tasks.dto.CreateTaskRequest;
+import com.taskpilot.projects.tasks.dto.KanbanMoveRequest;
+import com.taskpilot.projects.tasks.dto.LabelDto;
+import com.taskpilot.projects.tasks.dto.TaskDto;
+import com.taskpilot.projects.tasks.dto.UpdateTaskRequest;
 import com.taskpilot.projects.tasks.dto.UpdateTaskSprintRequest;
+import com.taskpilot.projects.projects.service.ProjectServiceImpl;
+import com.taskpilot.projects.projects.dto.CreateProjectRequest;
+import com.taskpilot.projects.projects.dto.ProjectResponse;
+import com.taskpilot.projects.projects.dto.UpdateProjectRequest;
+import com.taskpilot.projects.projects.dto.JoinProjectRequest;
+import com.taskpilot.projects.projects.dto.ProjectMemberResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
 import org.springframework.http.HttpStatus;
@@ -68,6 +83,8 @@ public class AiQueryModuleAdapter implements TaskCommandPort, ProjectInsightsPor
     private final NotificationPort notificationPort;
     private final SprintService sprintService;
     private final TaskService taskService;
+    private final LabelService labelService;
+    private final ProjectServiceImpl projectService;
 
     @Override
     @Transactional(readOnly = true)
@@ -173,45 +190,59 @@ public class AiQueryModuleAdapter implements TaskCommandPort, ProjectInsightsPor
 
     @Override
     @Transactional
-    public TaskSummaryDto createTask(Long projectId, String title, String description, String priority,
-            Long parentTaskId, Long sprintId, Integer difficultyLevel, Long assigneeId, String dueDate,
-            Long requesterUserId) {
-        validateProjectMember(projectId, requesterUserId);
-        validateProjectNotArchived(projectId);
-        validateParentTask(projectId, parentTaskId);
-        validateSprint(projectId, sprintId);
-        if (assigneeId != null) {
-            validateProjectMember(projectId, assigneeId);
-        }
+    public TaskSummaryDto updateTask(Long taskId, String title, String description, String status, String priority,
+            Float position, List<Long> labelIds, Integer difficultyLevel, List<Long> requiredSkillIds,
+            Long assigneeId, String startDate, String dueDate, Long requesterUserId) {
+        TaskEntity task = findTask(taskId);
+        String email = getRequesterEmail(requesterUserId);
+        UpdateTaskRequest request = new UpdateTaskRequest(
+                title,
+                description,
+                parseOptionalStatus(status),
+                parseOptionalPriority(priority),
+                position,
+                labelIds,
+                difficultyLevel,
+                requiredSkillIds,
+                assigneeId,
+                parseInstant(startDate),
+                parseInstant(dueDate));
+        return toTaskSummary(taskService.updateTask(taskId, request, email), task.getProjectId());
+    }
 
-        String safeTitle = title == null ? "" : title.trim();
-        if (safeTitle.isBlank()) {
-            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), "Task title is required");
-        }
+    @Override
+    @Transactional
+    public TaskSummaryDto createTask(Long projectId, String title, String description, String priority, Float position,
+            Long parentTaskId, Long sprintId, Integer difficultyLevel, List<Long> labelIds,
+            List<Long> requiredSkillIds, Long assigneeId, String startDate, String dueDate, Long requesterUserId) {
+        CreateTaskRequest request = new CreateTaskRequest(
+                projectId,
+                parentTaskId,
+                sprintId,
+                title,
+                description,
+                parsePriority(priority),
+                position,
+                labelIds,
+                difficultyLevel,
+                requiredSkillIds,
+                assigneeId,
+                parseInstant(startDate),
+                parseInstant(dueDate));
+        return toTaskSummary(taskService.createTask(request, getRequesterEmail(requesterUserId)));
+    }
 
-        TaskEntity task = TaskEntity.builder()
-                .projectId(projectId)
-                .parentId(parentTaskId)
-                .sprintId(sprintId)
-                .title(safeTitle)
-                .description(description)
-                .priority(parsePriority(priority))
-                .position(0f)
-                .difficultyLevel(safeDifficulty(difficultyLevel))
-                .assigneeId(assigneeId)
-                .reporterId(requesterUserId)
-                .dueDate(parseInstant(dueDate))
-                .status(TaskEntity.TaskStatus.TODO)
-                .build();
+    @Override
+    @Transactional
+    public void deleteTask(Long taskId, Long requesterUserId) {
+        taskService.deleteTask(taskId, getRequesterEmail(requesterUserId));
+    }
 
-        taskRepository.save(task);
-        if (assigneeId != null) {
-            notificationPort.sendSystemNotification(assigneeId, "Task Assigned",
-                    "You have been assigned to task: " + task.getTitle(),
-                    "/tasks?taskId=" + task.getId());
-        }
-
-        return toTaskSummary(task);
+    @Override
+    @Transactional
+    public TaskSummaryDto moveTaskKanban(Long taskId, String status, Float position, Long requesterUserId) {
+        KanbanMoveRequest request = new KanbanMoveRequest(parseStatus(status), position);
+        return toTaskSummary(taskService.moveTaskKanban(taskId, request, getRequesterEmail(requesterUserId)));
     }
 
     @Override
@@ -269,6 +300,175 @@ public class AiQueryModuleAdapter implements TaskCommandPort, ProjectInsightsPor
                             skills);
                 })
                 .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<LabelSummaryDto> getProjectLabels(Long projectId, Long requesterUserId) {
+        return labelService.getLabelsByProject(projectId, getRequesterEmail(requesterUserId)).stream()
+                .map(this::toLabelSummary)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public LabelSummaryDto createProjectLabel(Long projectId, String name, String color, Long requesterUserId) {
+        return toLabelSummary(labelService.createLabel(projectId, new CreateLabelRequest(name, color),
+                getRequesterEmail(requesterUserId)));
+    }
+
+    @Override
+    @Transactional
+    public void deleteProjectLabel(Long projectId, Long labelId, Long requesterUserId) {
+        labelService.deleteLabel(projectId, labelId, getRequesterEmail(requesterUserId));
+    }
+
+    @Override
+    @Transactional
+    public ProjectOverviewDto createProject(String name, String description, String startDate, String endDate, Long requesterUserId) {
+        String email = getRequesterEmail(requesterUserId);
+        LocalDate start = parseLocalDate(startDate);
+        LocalDate end = parseLocalDate(endDate);
+
+        CreateProjectRequest request = new CreateProjectRequest(
+                name,
+                description,
+                null,
+                start,
+                end
+        );
+
+        ProjectResponse response = projectService.createProject(request, email);
+        return new ProjectOverviewDto(
+                response.id(),
+                response.name(),
+                response.description(),
+                response.status() != null ? response.status().name() : null,
+                "MANAGER",
+                response.startDate() != null ? response.startDate().toString() : null,
+                response.endDate() != null ? response.endDate().toString() : null,
+                response.createdAt() != null ? response.createdAt().toString() : null
+        );
+    }
+
+    @Override
+    @Transactional
+    public ProjectOverviewDto updateProject(Long projectId, String name, String description, String status, String heuristicMode, String workflowMode, String startDate, String endDate, Long requesterUserId) {
+        String email = getRequesterEmail(requesterUserId);
+        LocalDate start = parseLocalDate(startDate);
+        LocalDate end = parseLocalDate(endDate);
+
+        UpdateProjectRequest request = new UpdateProjectRequest(
+                name,
+                description,
+                parseProjectStatus(status),
+                parseHeuristicMode(heuristicMode),
+                parseWorkflowMode(workflowMode),
+                start,
+                end
+        );
+
+        ProjectResponse response = projectService.updateProject(projectId, request, email);
+        return new ProjectOverviewDto(
+                response.id(),
+                response.name(),
+                response.description(),
+                response.status() != null ? response.status().name() : null,
+                "MANAGER",
+                response.startDate() != null ? response.startDate().toString() : null,
+                response.endDate() != null ? response.endDate().toString() : null,
+                response.createdAt() != null ? response.createdAt().toString() : null
+        );
+    }
+
+    @Override
+    @Transactional
+    public Object joinProject(String projectCode, Long requesterUserId) {
+        String email = getRequesterEmail(requesterUserId);
+        JoinProjectRequest request = new JoinProjectRequest(projectCode);
+        ProjectMemberResponse response = projectService.joinProject(request, email);
+        return response;
+    }
+
+    @Override
+    @Transactional
+    public void leaveProject(Long projectId, Long requesterUserId) {
+        String email = getRequesterEmail(requesterUserId);
+        projectService.leaveProject(projectId, email);
+    }
+
+    @Override
+    @Transactional
+    public void updateMemberRole(Long projectId, Long targetUserId, String role, Long requesterUserId) {
+        String email = getRequesterEmail(requesterUserId);
+        ProjectMemberEntity.MemberRole parsedRole = parseMemberRole(role);
+        projectService.updateMemberRole(projectId, targetUserId, parsedRole, email);
+    }
+
+    @Override
+    @Transactional
+    public void removeMember(Long projectId, Long targetUserId, Long requesterUserId) {
+        String email = getRequesterEmail(requesterUserId);
+        projectService.removeMember(projectId, targetUserId, email);
+    }
+
+    @Override
+    @Transactional
+    public void archiveProject(Long projectId, Long requesterUserId) {
+        String email = getRequesterEmail(requesterUserId);
+        projectService.archiveProject(projectId, email);
+    }
+
+    @Override
+    @Transactional
+    public void restoreProject(Long projectId, Long requesterUserId) {
+        String email = getRequesterEmail(requesterUserId);
+        projectService.restoreProject(projectId, email);
+    }
+
+    @Override
+    @Transactional
+    public void deleteProject(Long projectId, Long requesterUserId) {
+        String email = getRequesterEmail(requesterUserId);
+        projectService.deleteProject(projectId, email);
+    }
+
+    private ProjectEntity.ProjectStatus parseProjectStatus(String status) {
+        if (status == null || status.isBlank()) return null;
+        try {
+            return ProjectEntity.ProjectStatus.valueOf(status.trim().toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), "Invalid status. Use ACTIVE, COMPLETED, ARCHIVED");
+        }
+    }
+
+    private ProjectEntity.HeuristicMode parseHeuristicMode(String mode) {
+        if (mode == null || mode.isBlank()) return null;
+        try {
+            return ProjectEntity.HeuristicMode.valueOf(mode.trim().toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), "Invalid heuristic mode. Use BALANCED, SKILL_FIT_ONLY, WORKLOAD_ONLY");
+        }
+    }
+
+    private ProjectEntity.WorkflowMode parseWorkflowMode(String mode) {
+        if (mode == null || mode.isBlank()) return null;
+        try {
+            return ProjectEntity.WorkflowMode.valueOf(mode.trim().toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), "Invalid workflow mode. Use STANDARD, SCRUM, KANBAN");
+        }
+    }
+
+    private ProjectMemberEntity.MemberRole parseMemberRole(String role) {
+        if (role == null || role.isBlank()) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), "Role cannot be blank");
+        }
+        try {
+            return ProjectMemberEntity.MemberRole.valueOf(role.trim().toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), "Invalid role. Use MANAGER or MEMBER");
+        }
     }
 
     @Override
@@ -332,6 +532,21 @@ public class AiQueryModuleAdapter implements TaskCommandPort, ProjectInsightsPor
         LocalDate end = parseLocalDate(endDate);
         CreateSprintRequest request = new CreateSprintRequest(name, goal, start, end);
         return toSprintSummary(sprintService.createSprint(projectId, request, email));
+    }
+
+    @Override
+    @Transactional
+    public SprintSummaryDto updateSprint(Long projectId, Long sprintId, String name, String startDate, String endDate,
+            String goal, Long requesterUserId) {
+        String email = getRequesterEmail(requesterUserId);
+        UpdateSprintRequest request = new UpdateSprintRequest(name, goal, parseLocalDate(startDate), parseLocalDate(endDate));
+        return toSprintSummary(sprintService.updateSprint(projectId, sprintId, request, email));
+    }
+
+    @Override
+    @Transactional
+    public void deleteSprint(Long projectId, Long sprintId, Long requesterUserId) {
+        sprintService.deleteSprint(projectId, sprintId, getRequesterEmail(requesterUserId));
     }
 
     @Override
@@ -440,6 +655,34 @@ public class AiQueryModuleAdapter implements TaskCommandPort, ProjectInsightsPor
                 task.getDueDate() != null ? task.getDueDate().toString() : null,
                 task.getCreatedAt() != null ? task.getCreatedAt().toString() : null,
                 task.getUpdatedAt() != null ? task.getUpdatedAt().toString() : null);
+    }
+
+    private TaskSummaryDto toTaskSummary(TaskDto task) {
+        return toTaskSummary(task, task.projectId());
+    }
+
+    private TaskSummaryDto toTaskSummary(TaskDto task, Long fallbackProjectId) {
+        UserProfileDto assignee = task.assigneeId() == null ? null
+                : userPort.findById(task.assigneeId()).orElse(null);
+        return new TaskSummaryDto(
+                task.id(),
+                task.projectId() != null ? task.projectId() : fallbackProjectId,
+                task.parentId(),
+                task.sprintId(),
+                task.title(),
+                task.description(),
+                task.status() != null ? task.status().name() : null,
+                task.priority() != null ? task.priority().name() : null,
+                task.difficultyLevel(),
+                task.assigneeId(),
+                assignee != null ? assignee.fullName() : null,
+                task.dueDate() != null ? task.dueDate().toString() : null,
+                task.createdAt() != null ? task.createdAt().toString() : null,
+                task.updatedAt() != null ? task.updatedAt().toString() : null);
+    }
+
+    private LabelSummaryDto toLabelSummary(LabelDto label) {
+        return new LabelSummaryDto(label.id(), label.name(), label.color());
     }
 
     private TaskDetailDto toTaskDetail(TaskEntity task) {
@@ -568,6 +811,14 @@ public class AiQueryModuleAdapter implements TaskCommandPort, ProjectInsightsPor
             throw new BusinessException(HttpStatus.BAD_REQUEST.value(),
                     "Invalid task priority. Allowed values: LOW, MEDIUM, HIGH, URGENT");
         }
+    }
+
+    private TaskEntity.TaskStatus parseOptionalStatus(String status) {
+        return status == null || status.isBlank() ? null : parseStatus(status);
+    }
+
+    private TaskEntity.PriorityLevel parseOptionalPriority(String priority) {
+        return priority == null || priority.isBlank() ? null : parsePriority(priority);
     }
 
     private String normalizeEnum(String value) {

--- a/taskpilot-projects/src/main/java/com/taskpilot/projects/tasks/service/TaskCommentService.java
+++ b/taskpilot-projects/src/main/java/com/taskpilot/projects/tasks/service/TaskCommentService.java
@@ -24,6 +24,8 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.taskpilot.contracts.aiquery.dto.TaskCommentSummaryDto;
 import com.taskpilot.contracts.aiquery.port.out.TaskCommentQueryPort;
+import com.taskpilot.contracts.assignment.dto.UserProfileDto;
+import com.taskpilot.contracts.assignment.port.out.UserPort;
 import com.taskpilot.contracts.user.dto.NotificationTypeDto;
 import com.taskpilot.contracts.user.dto.SystemNotificationCommandDto;
 import com.taskpilot.contracts.user.dto.UserProfileLiteDto;
@@ -58,6 +60,7 @@ public class TaskCommentService implements TaskCommentQueryPort {
     private final ProjectRepository projectRepository;
     private final ProjectMemberRepository projectMemberRepository;
     private final UserIdentityPort userIdentityPort;
+    private final UserPort userPort;
     private final UserProfilePort userProfilePort;
     private final UserNotificationPort userNotificationPort;
     private final TaskCommentRealtimeService realtimeService;
@@ -225,18 +228,56 @@ public class TaskCommentService implements TaskCommentQueryPort {
         validateUserIsMember(task.getProjectId(), requesterUserId);
 
         return mapToDtos(commentRepository.findByTaskIdOrderByCreatedAtAsc(taskId)).stream()
-                .map(comment -> new TaskCommentSummaryDto(
-                        comment.id(),
-                        comment.taskId(),
-                        comment.parentCommentId(),
-                        comment.author().id(),
-                        comment.author().fullName(),
-                        comment.content(),
-                        comment.mentions().stream().map(UserProfileLiteDto::id).toList(),
-                        comment.deleted(),
-                        comment.createdAt(),
-                        comment.updatedAt()))
+                .map(this::toSummaryDto)
                 .toList();
+    }
+
+    @Override
+    @Transactional
+    public TaskCommentSummaryDto createTaskComment(Long taskId, String content, Long parentCommentId,
+            List<Long> mentionedUserIds, Long requesterUserId) {
+        return toSummaryDto(createComment(taskId,
+                new CreateTaskCommentRequest(content, parentCommentId, toMentionSet(mentionedUserIds)),
+                getRequesterEmail(requesterUserId)));
+    }
+
+    @Override
+    @Transactional
+    public TaskCommentSummaryDto updateTaskComment(Long taskId, Long commentId, String content,
+            List<Long> mentionedUserIds, Long requesterUserId) {
+        return toSummaryDto(updateComment(taskId, commentId,
+                new UpdateTaskCommentRequest(content, toMentionSet(mentionedUserIds)),
+                getRequesterEmail(requesterUserId)));
+    }
+
+    @Override
+    @Transactional
+    public TaskCommentSummaryDto deleteTaskComment(Long taskId, Long commentId, Long requesterUserId) {
+        return toSummaryDto(deleteComment(taskId, commentId, getRequesterEmail(requesterUserId)));
+    }
+
+    private String getRequesterEmail(Long requesterUserId) {
+        return userPort.findById(requesterUserId)
+                .map(UserProfileDto::email)
+                .orElseThrow(() -> new BusinessException(HttpStatus.NOT_FOUND.value(), "User not found"));
+    }
+
+    private Set<Long> toMentionSet(List<Long> mentionedUserIds) {
+        return mentionedUserIds == null ? Set.of() : new LinkedHashSet<>(mentionedUserIds);
+    }
+
+    private TaskCommentSummaryDto toSummaryDto(TaskCommentDto comment) {
+        return new TaskCommentSummaryDto(
+                comment.id(),
+                comment.taskId(),
+                comment.parentCommentId(),
+                comment.author().id(),
+                comment.author().fullName(),
+                comment.content(),
+                comment.mentions().stream().map(UserProfileLiteDto::id).toList(),
+                comment.deleted(),
+                comment.createdAt(),
+                comment.updatedAt());
     }
 
     private TaskEntity findTask(Long taskId) {

--- a/taskpilot-projects/src/test/java/com/taskpilot/projects/tasks/service/TaskCommentServiceTest.java
+++ b/taskpilot-projects/src/test/java/com/taskpilot/projects/tasks/service/TaskCommentServiceTest.java
@@ -35,6 +35,7 @@ import com.taskpilot.contracts.user.dto.UserProfileLiteDto;
 import com.taskpilot.contracts.user.port.out.UserIdentityPort;
 import com.taskpilot.contracts.user.port.out.UserNotificationPort;
 import com.taskpilot.contracts.user.port.out.UserProfilePort;
+import com.taskpilot.contracts.assignment.port.out.UserPort;
 import com.taskpilot.infrastructure.exception.BusinessException;
 import com.taskpilot.projects.common.entity.CommentEntity;
 import com.taskpilot.projects.common.entity.CommentMentionEntity;
@@ -74,6 +75,8 @@ class TaskCommentServiceTest {
     @Mock
     private UserIdentityPort userIdentityPort;
     @Mock
+    private UserPort userPort;
+    @Mock
     private UserProfilePort userProfilePort;
     @Mock
     private UserNotificationPort userNotificationPort;
@@ -91,6 +94,7 @@ class TaskCommentServiceTest {
                 projectRepository,
                 projectMemberRepository,
                 userIdentityPort,
+                userPort,
                 userProfilePort,
                 userNotificationPort,
                 realtimeService);


### PR DESCRIPTION
This PR exposes all project and member CUD (create, update, delete, archive, restore, join, leave, role update) operations to the TaskPilot AI chatbot.